### PR TITLE
Added .gitmodules file, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Prerequisites
-.*
 !.gitignore
 *~
 *.d
@@ -36,7 +35,7 @@
 
 # Cmake
 build/
-
+Testing/
 CMakeSettings.json
 compile_commands.json
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/googletest"]
+	path = extern/googletest
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
Fixes #8 

`.gitignore` now tolerates `.`files and it restricts `Testing/` directory
used for **ctest** logs